### PR TITLE
PostToday & PostYesterday Tests, Added Categories

### DIFF
--- a/APITestProject/APITests/NameDayTodayTests/GetToday/GET_NameDayServiceForTodayIsCalled_WithInvalidParameters.cs
+++ b/APITestProject/APITests/NameDayTodayTests/GetToday/GET_NameDayServiceForTodayIsCalled_WithInvalidParameters.cs
@@ -6,7 +6,8 @@ using System.Threading.Tasks;
 
 namespace APITests.NameDayTodayTests.GetToday;
 
-public class WhenNameDayServiceIsCalled_WithInvalidParameters
+[Category("GetToday")]
+public class WhenNameDayForTodayServiceIsCalled_WithGetMethodAndInvalidParameters
 {
     NamedayForTodayService _nameDayForTodayService;
     [OneTimeSetUp]

--- a/APITestProject/APITests/NameDayTodayTests/GetToday/GET_NameDayServiceForTodayIsCalled_WithValidParameters.cs
+++ b/APITestProject/APITests/NameDayTodayTests/GetToday/GET_NameDayServiceForTodayIsCalled_WithValidParameters.cs
@@ -6,12 +6,15 @@ using System.Threading.Tasks;
 
 namespace APITests.NameDayTodayTests.GetToday;
 
-public class GET_NameDayServiceForTodayIsCalled_WithValidParameters
+[Category("GetToday")]
+public class WhenNameDayForTodayServiceIsCalled_WithGetMethodAndValidParameters
 {
     NamedayForTodayService _nameDayForTodayService;
+    DateTime _apiDefaultTime;
     [OneTimeSetUp]
     public void Setup()
     {
+        _apiDefaultTime = DateTime.UtcNow.AddHours(2);
         _nameDayForTodayService = new NamedayForTodayService();
     }
 
@@ -33,8 +36,8 @@ public class GET_NameDayServiceForTodayIsCalled_WithValidParameters
     public async Task GivenNoParameters_DateIsToday()
     {
         await _nameDayForTodayService.MakeRequest(Method.Get);
-        Assert.That(_nameDayForTodayService.NamedayTodayDTO.Response.day, Is.EqualTo(DateTime.Now.Day));
-        Assert.That(_nameDayForTodayService.NamedayTodayDTO.Response.month, Is.EqualTo(DateTime.Now.Month));
+        Assert.That(_nameDayForTodayService.NamedayTodayDTO.Response.day, Is.EqualTo(_apiDefaultTime.Day));
+        Assert.That(_nameDayForTodayService.NamedayTodayDTO.Response.month, Is.EqualTo(_apiDefaultTime.Month));
     }
 
     [Test]
@@ -70,8 +73,8 @@ public class GET_NameDayServiceForTodayIsCalled_WithValidParameters
         };
 
         await _nameDayForTodayService.MakeRequest(param, Method.Get);
-        Assert.That(_nameDayForTodayService.NamedayTodayDTO.Response.day, Is.EqualTo(DateTime.Now.Day));
-        Assert.That(_nameDayForTodayService.NamedayTodayDTO.Response.month, Is.EqualTo(DateTime.Now.Month));
+        Assert.That(_nameDayForTodayService.NamedayTodayDTO.Response.day, Is.EqualTo(_apiDefaultTime.Day));
+        Assert.That(_nameDayForTodayService.NamedayTodayDTO.Response.month, Is.EqualTo(_apiDefaultTime.Month));
     }
 
     [Test]

--- a/APITestProject/APITests/NameDayTodayTests/PostToday/POST_NameDayServiceForTodayIsCalled_WithInvalidParameters.cs
+++ b/APITestProject/APITests/NameDayTodayTests/PostToday/POST_NameDayServiceForTodayIsCalled_WithInvalidParameters.cs
@@ -4,9 +4,63 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace APITests.NameDayTodayTests.PostToday
+namespace APITests.NameDayTodayTests.PostToday;
+
+[Category("PostToday")]
+public class WhenNameDayForTodayServiceIsCalled_WithPostMethodAndInvalidParameters
 {
-    public class POST_NameDayServiceForTomorrowIsCalled_WithInvalidParameters
+    NamedayForTodayService _nameDayForTodayService;
+    [OneTimeSetUp]
+    public void Setup()
     {
+        _nameDayForTodayService = new NamedayForTodayService();
+    }
+
+    [Test]
+    public async Task SpecifiedCountryIsInvalid_Status422()
+    {
+        var param = new Dictionary<string, string>
+        {
+            { "country", "aa" }
+        };
+        await _nameDayForTodayService.MakeRequest(param, Method.Post);
+
+        Assert.That(_nameDayForTodayService.GetStatusCode(), Is.EqualTo(422));
+    }
+
+    [Test]
+    public async Task SpecifiedCountryIsInvalid_GivesRelevantErrorMessage()
+    {
+        var param = new Dictionary<string, string>
+        {
+            { "country", "aa" }
+        };
+        await _nameDayForTodayService.MakeRequest(param, Method.Post);
+
+        Assert.That(_nameDayForTodayService.JsonResponse["error"]["country"][0].ToString(), Is.EqualTo("The selected country is invalid."));
+    }
+
+    [Test]
+    public async Task SpecifiedTimezoneIsInvalid_Status422()
+    {
+        var param = new Dictionary<string, string>
+        {
+            { "timezone", "aa" }
+        };
+        await _nameDayForTodayService.MakeRequest(param, Method.Post);
+
+        Assert.That(_nameDayForTodayService.GetStatusCode(), Is.EqualTo(422));
+    }
+
+    [Test]
+    public async Task SpecifiedTimezoneIsInvalid_GivesRelevantErrorMessage()
+    {
+        var param = new Dictionary<string, string>
+        {
+            { "timezone", "aa" }
+        };
+        await _nameDayForTodayService.MakeRequest(param, Method.Post);
+
+        Assert.That(_nameDayForTodayService.JsonResponse["error"]["timezone"][0].ToString(), Is.EqualTo("The selected timezone is invalid."));
     }
 }

--- a/APITestProject/APITests/NameDayTodayTests/PostToday/POST_NameDayServiceForTodayIsCalled_WithValidParameters.cs
+++ b/APITestProject/APITests/NameDayTodayTests/PostToday/POST_NameDayServiceForTodayIsCalled_WithValidParameters.cs
@@ -4,9 +4,132 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace APITests.NameDayTodayTests.PostToday
+namespace APITests.NameDayTodayTests.PostToday;
+
+[Category("PostToday")]
+public class WhenNameDayForTodayServiceIsCalled_WithPostMethodAndValidParameters
 {
-    public class POST_NameDayServiceForTomorrowIsCalled_WithValidParameters
+    NamedayForTodayService _nameDayForTodayService;
+    DateTime _apiDefaultTime;
+    [OneTimeSetUp]
+    public void Setup()
     {
+        _apiDefaultTime = DateTime.UtcNow.AddHours(2);
+        _nameDayForTodayService = new NamedayForTodayService();
+    }
+
+    [Test]
+    public async Task GivenNoParameters_Status200()
+    {
+        await _nameDayForTodayService.MakeRequest(Method.Post);
+        Assert.That(_nameDayForTodayService.GetStatusCode(), Is.EqualTo(200));
+    }
+
+    [Test]
+    public async Task GivenNoParameters_GivesAllCountryData()
+    {
+        await _nameDayForTodayService.MakeRequest(Method.Post);
+        Assert.That(_nameDayForTodayService.JsonResponse["nameday"].Count, Is.EqualTo(20));
+    }
+
+    [Test]
+    public async Task GivenNoParameters_DateIsToday()
+    {
+        await _nameDayForTodayService.MakeRequest(Method.Post);
+        Assert.That(_nameDayForTodayService.NamedayTodayDTO.Response.day, Is.EqualTo(_apiDefaultTime.Day));
+        Assert.That(_nameDayForTodayService.NamedayTodayDTO.Response.month, Is.EqualTo(_apiDefaultTime.Month));
+    }
+
+    [Test]
+    public async Task GivenCountry_Status200()
+    {
+        var param = new Dictionary<string, string>
+        {
+            {"country", "pl" }
+        };
+
+        await _nameDayForTodayService.MakeRequest(param, Method.Post);
+        Assert.That(_nameDayForTodayService.GetStatusCode(), Is.EqualTo(200));
+    }
+
+    [Test]
+    public async Task GivenCountry_GivesCountryData()
+    {
+        var param = new Dictionary<string, string>
+        {
+            {"country", "es" }
+        };
+
+        await _nameDayForTodayService.MakeRequest(param, Method.Post);
+        Assert.That(_nameDayForTodayService.JsonResponse["nameday"].Count, Is.EqualTo(1));
+    }
+
+    [Test]
+    public async Task GivenCountry_DateIsToday()
+    {
+        var param = new Dictionary<string, string>
+        {
+            {"country", "us" }
+        };
+
+        await _nameDayForTodayService.MakeRequest(param, Method.Post);
+        Assert.That(_nameDayForTodayService.NamedayTodayDTO.Response.day, Is.EqualTo(_apiDefaultTime.Day));
+        Assert.That(_nameDayForTodayService.NamedayTodayDTO.Response.month, Is.EqualTo(_apiDefaultTime.Month));
+    }
+
+    [Test]
+    public async Task GivenTimezone_Status200()
+    {
+        var param = new Dictionary<string, string>
+        {
+            {"timezone", "Europe/London" }
+        };
+
+        await _nameDayForTodayService.MakeRequest(param, Method.Post);
+        Assert.That(_nameDayForTodayService.GetStatusCode(), Is.EqualTo(200));
+    }
+
+    [Test]
+    public async Task GivenTimezone_GivesAllCountryData()
+    {
+        var param = new Dictionary<string, string>
+        {
+            {"timezone", "Europe/Lisbon" }
+        };
+
+        await _nameDayForTodayService.MakeRequest(param, Method.Post);
+        Assert.That(_nameDayForTodayService.JsonResponse["nameday"].Count, Is.EqualTo(20));
+    }
+
+    [Test]
+    public async Task GivenTimezone_DateIsToday()
+    {
+        var param = new Dictionary<string, string>
+        {
+            {"timezone", "Australia/Brisbane" }
+        };
+
+        var date = DateTime.Now.AddHours(9);
+
+        await _nameDayForTodayService.MakeRequest(param, Method.Post);
+        Assert.That(_nameDayForTodayService.NamedayTodayDTO.Response.day, Is.EqualTo(date.Day));
+        Assert.That(_nameDayForTodayService.NamedayTodayDTO.Response.month, Is.EqualTo(date.Month));
+    }
+
+    [Test]
+    public async Task GivenCountryAndTimezone_DateIsTodayAndCountryDataIsListed()
+    {
+        var param = new Dictionary<string, string>
+        {
+            {"country", "es" },
+            {"timezone", "Australia/Brisbane" }
+        };
+
+        var date = DateTime.Now.AddHours(9);
+
+        await _nameDayForTodayService.MakeRequest(param, Method.Post);
+        Assert.That(_nameDayForTodayService.NamedayTodayDTO.Response.day, Is.EqualTo(date.Day));
+        Assert.That(_nameDayForTodayService.NamedayTodayDTO.Response.month, Is.EqualTo(date.Month));
+        Assert.That(_nameDayForTodayService.JsonResponse["nameday"].Count, Is.EqualTo(1));
     }
 }

--- a/APITestProject/APITests/NameDayYesterdayTests/GetYesterday/GET_NameDayServiceForYesterdayIsCalled_WithInvalidParameters.cs
+++ b/APITestProject/APITests/NameDayYesterdayTests/GetYesterday/GET_NameDayServiceForYesterdayIsCalled_WithInvalidParameters.cs
@@ -4,9 +4,63 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace APITests.NameDayYesterdayTests.GetYesterday
+namespace APITests.NameDayYesterdayTests.GetYesterday;
+
+[Category("GetYesterday")]
+public class WhenNameDayForYesterdayServiceIsCalled_WithGetMethodAndInvalidParameters
 {
-    public class GET_NameDayServiceForYesterdayIsCalled_WithInvalidParameters
+    NamedayForYesterdayService _nameDayForYesterdayService;
+    [OneTimeSetUp]
+    public void Setup()
     {
+        _nameDayForYesterdayService = new NamedayForYesterdayService();
+    }
+
+    [Test]
+    public async Task SpecifiedCountryIsInvalid_Status422()
+    {
+        var param = new Dictionary<string, string>
+        {
+        { "country", "aa" }
+        };
+        await _nameDayForYesterdayService.MakeRequest(param, Method.Get);
+
+        Assert.That(_nameDayForYesterdayService.GetStatusCode(), Is.EqualTo(422));
+    }
+
+    [Test]
+    public async Task SpecifiedCountryIsInvalid_GivesRelevantErrorMessage()
+    {
+        var param = new Dictionary<string, string>
+    {
+        { "country", "aa" }
+    };
+        await _nameDayForYesterdayService.MakeRequest(param, Method.Get);
+
+        Assert.That(_nameDayForYesterdayService.JsonResponse["error"]["country"][0].ToString(), Is.EqualTo("The selected country is invalid."));
+    }
+
+    [Test]
+    public async Task SpecifiedTimezoneIsInvalid_Status422()
+    {
+        var param = new Dictionary<string, string>
+    {
+        { "timezone", "aa" }
+    };
+        await _nameDayForYesterdayService.MakeRequest(param, Method.Get);
+
+        Assert.That(_nameDayForYesterdayService.GetStatusCode(), Is.EqualTo(422));
+    }
+
+    [Test]
+    public async Task SpecifiedTimezoneIsInvalid_GivesRelevantErrorMessage()
+    {
+        var param = new Dictionary<string, string>
+    {
+        { "timezone", "aa" }
+    };
+        await _nameDayForYesterdayService.MakeRequest(param, Method.Get);
+
+        Assert.That(_nameDayForYesterdayService.JsonResponse["error"]["timezone"][0].ToString(), Is.EqualTo("The selected timezone is invalid."));
     }
 }

--- a/APITestProject/APITests/NameDayYesterdayTests/GetYesterday/GET_NameDayServiceForYesterdayIsCalled_WithValidParameters.cs
+++ b/APITestProject/APITests/NameDayYesterdayTests/GetYesterday/GET_NameDayServiceForYesterdayIsCalled_WithValidParameters.cs
@@ -4,9 +4,133 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace APITests.NameDayYesterdayTests.GetYesterday
+
+namespace APITests.NameDayYesterdayTests.GetYesterday;
+
+[Category("GetYesterday")]
+public class WhenNameDayForYesterdayServiceIsCalled_WithGetMethodAndValidParameters
 {
-    public class GET_NameDayServiceForYesterdayIsCalled_WithValidParameters
+    NamedayForYesterdayService _nameDayForYesterdayService;
+    DateTime _apiDefaultTime;
+    [OneTimeSetUp]
+    public void Setup()
     {
+        _apiDefaultTime = DateTime.UtcNow.AddHours(2);
+        _nameDayForYesterdayService = new NamedayForYesterdayService();
+    }
+
+    [Test]
+    public async Task GivenNoParameters_Status200()
+    {
+        await _nameDayForYesterdayService.MakeRequest(Method.Get);
+        Assert.That(_nameDayForYesterdayService.GetStatusCode(), Is.EqualTo(200));
+    }
+
+    [Test]
+    public async Task GivenNoParameters_GivesAllCountryData()
+    {
+        await _nameDayForYesterdayService.MakeRequest(Method.Get);
+        Assert.That(_nameDayForYesterdayService.JsonResponse["nameday"].Count, Is.EqualTo(20));
+    }
+
+    [Test]
+    public async Task GivenNoParameters_DateIsYesterday()
+    {
+        await _nameDayForYesterdayService.MakeRequest(Method.Get);
+        Assert.That(_nameDayForYesterdayService.NamedayTodayDTO.Response.day, Is.EqualTo(_apiDefaultTime.Day - 1));
+        Assert.That(_nameDayForYesterdayService.NamedayTodayDTO.Response.month, Is.EqualTo(_apiDefaultTime.Month));
+    }
+
+    [Test]
+    public async Task GivenCountry_Status200()
+    {
+        var param = new Dictionary<string, string>
+    {
+        {"country", "pl" }
+    };
+
+        await _nameDayForYesterdayService.MakeRequest(param, Method.Get);
+        Assert.That(_nameDayForYesterdayService.GetStatusCode(), Is.EqualTo(200));
+    }
+
+    [Test]
+    public async Task GivenCountry_GivesCountryData()
+    {
+        var param = new Dictionary<string, string>
+    {
+        {"country", "es" }
+    };
+
+        await _nameDayForYesterdayService.MakeRequest(param, Method.Get);
+        Assert.That(_nameDayForYesterdayService.JsonResponse["nameday"].Count, Is.EqualTo(1));
+    }
+
+    [Test]
+    public async Task GivenCountry_DateIsYesterday()
+    {
+        var param = new Dictionary<string, string>
+    {
+        {"country", "us" }
+    };
+
+        await _nameDayForYesterdayService.MakeRequest(param, Method.Get);
+        Assert.That(_nameDayForYesterdayService.NamedayTodayDTO.Response.day, Is.EqualTo(_apiDefaultTime.Day - 1));
+        Assert.That(_nameDayForYesterdayService.NamedayTodayDTO.Response.month, Is.EqualTo(_apiDefaultTime.Month));
+    }
+
+    [Test]
+    public async Task GivenTimezone_Status200()
+    {
+        var param = new Dictionary<string, string>
+    {
+        {"timezone", "Europe/London" }
+    };
+
+        await _nameDayForYesterdayService.MakeRequest(param, Method.Get);
+        Assert.That(_nameDayForYesterdayService.GetStatusCode(), Is.EqualTo(200));
+    }
+
+    [Test]
+    public async Task GivenTimezone_GivesAllCountryData()
+    {
+        var param = new Dictionary<string, string>
+    {
+        {"timezone", "Europe/Lisbon" }
+    };
+
+        await _nameDayForYesterdayService.MakeRequest(param, Method.Get);
+        Assert.That(_nameDayForYesterdayService.JsonResponse["nameday"].Count, Is.EqualTo(20));
+    }
+
+    [Test]
+    public async Task GivenTimezone_DateIsYesterday()
+    {
+        var param = new Dictionary<string, string>
+    {
+        {"timezone", "Australia/Brisbane" }
+    };
+
+        var date = DateTime.Now.AddHours(9);
+
+        await _nameDayForYesterdayService.MakeRequest(param, Method.Get);
+        Assert.That(_nameDayForYesterdayService.NamedayTodayDTO.Response.day, Is.EqualTo(date.Day - 1));
+        Assert.That(_nameDayForYesterdayService.NamedayTodayDTO.Response.month, Is.EqualTo(date.Month));
+    }
+
+    [Test]
+    public async Task GivenCountryAndTimezone_DateIsYesterdayAndCountryDataIsListed()
+    {
+        var param = new Dictionary<string, string>
+    {
+        {"country", "es" },
+        {"timezone", "Australia/Brisbane" }
+    };
+
+        var date = DateTime.Now.AddHours(9);
+
+        await _nameDayForYesterdayService.MakeRequest(param, Method.Get);
+        Assert.That(_nameDayForYesterdayService.NamedayTodayDTO.Response.day, Is.EqualTo(date.Day - 1));
+        Assert.That(_nameDayForYesterdayService.NamedayTodayDTO.Response.month, Is.EqualTo(date.Month));
+        Assert.That(_nameDayForYesterdayService.JsonResponse["nameday"].Count, Is.EqualTo(1));
     }
 }

--- a/APITestProject/APITests/NameDayYesterdayTests/PostYesterday/POST_NameDayServiceForYesterdayIsCalled_WithInvalidParameters.cs
+++ b/APITestProject/APITests/NameDayYesterdayTests/PostYesterday/POST_NameDayServiceForYesterdayIsCalled_WithInvalidParameters.cs
@@ -4,9 +4,63 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace APITests.NameDayYesterdayTests.PostYesterday
+namespace APITests.NameDayYesterdayTests.PostYesterday;
+
+[Category("PostYesterday")]
+public class WhenNameDayForYesterdayServiceIsCalled_WithPostMethodAndInvalidParameters
 {
-    public class POST_NameDayServiceForYesterdayIsCalled_WithInvalidParameters
+    NamedayForYesterdayService _nameDayForYesterdayService;
+    [OneTimeSetUp]
+    public void Setup()
     {
+        _nameDayForYesterdayService = new NamedayForYesterdayService();
+    }
+
+    [Test]
+    public async Task SpecifiedCountryIsInvalid_Status422()
+    {
+        var param = new Dictionary<string, string>
+        {
+        { "country", "aa" }
+        };
+        await _nameDayForYesterdayService.MakeRequest(param, Method.Post);
+
+        Assert.That(_nameDayForYesterdayService.GetStatusCode(), Is.EqualTo(422));
+    }
+
+    [Test]
+    public async Task SpecifiedCountryIsInvalid_GivesRelevantErrorMessage()
+    {
+        var param = new Dictionary<string, string>
+    {
+        { "country", "aa" }
+    };
+        await _nameDayForYesterdayService.MakeRequest(param, Method.Post);
+
+        Assert.That(_nameDayForYesterdayService.JsonResponse["error"]["country"][0].ToString(), Is.EqualTo("The selected country is invalid."));
+    }
+
+    [Test]
+    public async Task SpecifiedTimezoneIsInvalid_Status422()
+    {
+        var param = new Dictionary<string, string>
+    {
+        { "timezone", "aa" }
+    };
+        await _nameDayForYesterdayService.MakeRequest(param, Method.Post);
+
+        Assert.That(_nameDayForYesterdayService.GetStatusCode(), Is.EqualTo(422));
+    }
+
+    [Test]
+    public async Task SpecifiedTimezoneIsInvalid_GivesRelevantErrorMessage()
+    {
+        var param = new Dictionary<string, string>
+    {
+        { "timezone", "aa" }
+    };
+        await _nameDayForYesterdayService.MakeRequest(param, Method.Post);
+
+        Assert.That(_nameDayForYesterdayService.JsonResponse["error"]["timezone"][0].ToString(), Is.EqualTo("The selected timezone is invalid."));
     }
 }

--- a/APITestProject/APITests/NameDayYesterdayTests/PostYesterday/POST_NameDayServiceForYesterdayIsCalled_WithValidParameters.cs
+++ b/APITestProject/APITests/NameDayYesterdayTests/PostYesterday/POST_NameDayServiceForYesterdayIsCalled_WithValidParameters.cs
@@ -4,9 +4,132 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace APITests.NameDayYesterdayTests.PostYesterday
+namespace APITests.NameDayYesterdayTests.PostYesterday;
+
+[Category("PostYesterday")]
+public class WhenNameDayForYesterdayServiceIsCalled_WithPostMethodAndValidParameters
 {
-    public class POST_NameDayServiceForYesterdayIsCalled_WithValidParameters
+    NamedayForYesterdayService _nameDayForYesterdayService;
+    DateTime _apiDefaultTime;
+    [OneTimeSetUp]
+    public void Setup()
     {
+        _apiDefaultTime = DateTime.UtcNow.AddHours(2);
+        _nameDayForYesterdayService = new NamedayForYesterdayService();
+    }
+
+    [Test]
+    public async Task GivenNoParameters_Status200()
+    {
+        await _nameDayForYesterdayService.MakeRequest(Method.Post);
+        Assert.That(_nameDayForYesterdayService.GetStatusCode(), Is.EqualTo(200));
+    }
+
+    [Test]
+    public async Task GivenNoParameters_GivesAllCountryData()
+    {
+        await _nameDayForYesterdayService.MakeRequest(Method.Post);
+        Assert.That(_nameDayForYesterdayService.JsonResponse["nameday"].Count, Is.EqualTo(20));
+    }
+
+    [Test]
+    public async Task GivenNoParameters_DateIsYesterday()
+    {
+        await _nameDayForYesterdayService.MakeRequest(Method.Post);
+        Assert.That(_nameDayForYesterdayService.NamedayTodayDTO.Response.day, Is.EqualTo(_apiDefaultTime.Day - 1));
+        Assert.That(_nameDayForYesterdayService.NamedayTodayDTO.Response.month, Is.EqualTo(_apiDefaultTime.Month));
+    }
+
+    [Test]
+    public async Task GivenCountry_Status200()
+    {
+        var param = new Dictionary<string, string>
+{
+    {"country", "pl" }
+};
+
+        await _nameDayForYesterdayService.MakeRequest(param, Method.Post);
+        Assert.That(_nameDayForYesterdayService.GetStatusCode(), Is.EqualTo(200));
+    }
+
+    [Test]
+    public async Task GivenCountry_GivesCountryData()
+    {
+        var param = new Dictionary<string, string>
+{
+    {"country", "es" }
+};
+
+        await _nameDayForYesterdayService.MakeRequest(param, Method.Post);
+        Assert.That(_nameDayForYesterdayService.JsonResponse["nameday"].Count, Is.EqualTo(1));
+    }
+
+    [Test]
+    public async Task GivenCountry_DateIsYesterday()
+    {
+        var param = new Dictionary<string, string>
+{
+    {"country", "us" }
+};
+
+        await _nameDayForYesterdayService.MakeRequest(param, Method.Post);
+        Assert.That(_nameDayForYesterdayService.NamedayTodayDTO.Response.day, Is.EqualTo(_apiDefaultTime.Day - 1));
+        Assert.That(_nameDayForYesterdayService.NamedayTodayDTO.Response.month, Is.EqualTo(_apiDefaultTime.Month));
+    }
+
+    [Test]
+    public async Task GivenTimezone_Status200()
+    {
+        var param = new Dictionary<string, string>
+{
+    {"timezone", "Europe/London" }
+};
+
+        await _nameDayForYesterdayService.MakeRequest(param, Method.Post);
+        Assert.That(_nameDayForYesterdayService.GetStatusCode(), Is.EqualTo(200));
+    }
+
+    [Test]
+    public async Task GivenTimezone_GivesAllCountryData()
+    {
+        var param = new Dictionary<string, string>
+{
+    {"timezone", "Europe/Lisbon" }
+};
+
+        await _nameDayForYesterdayService.MakeRequest(param, Method.Post);
+        Assert.That(_nameDayForYesterdayService.JsonResponse["nameday"].Count, Is.EqualTo(20));
+    }
+
+    [Test]
+    public async Task GivenTimezone_DateIsYesterday()
+    {
+        var param = new Dictionary<string, string>
+{
+    {"timezone", "Australia/Brisbane" }
+};
+
+        var date = DateTime.Now.AddHours(9);
+
+        await _nameDayForYesterdayService.MakeRequest(param, Method.Post);
+        Assert.That(_nameDayForYesterdayService.NamedayTodayDTO.Response.day, Is.EqualTo(date.Day - 1));
+        Assert.That(_nameDayForYesterdayService.NamedayTodayDTO.Response.month, Is.EqualTo(date.Month));
+    }
+
+    [Test]
+    public async Task GivenCountryAndTimezone_DateIsYesterdayAndCountryDataIsListed()
+    {
+        var param = new Dictionary<string, string>
+{
+    {"country", "es" },
+    {"timezone", "Australia/Brisbane" }
+};
+
+        var date = DateTime.Now.AddHours(9);
+
+        await _nameDayForYesterdayService.MakeRequest(param, Method.Post);
+        Assert.That(_nameDayForYesterdayService.NamedayTodayDTO.Response.day, Is.EqualTo(date.Day - 1));
+        Assert.That(_nameDayForYesterdayService.NamedayTodayDTO.Response.month, Is.EqualTo(date.Month));
+        Assert.That(_nameDayForYesterdayService.JsonResponse["nameday"].Count, Is.EqualTo(1));
     }
 }


### PR DESCRIPTION
Added PostToday and PostYesterday tests, Added Categories to Tests and fixed an issue where the default API time is different to the local time when testing. Default API Time is UTC+2